### PR TITLE
Build via script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task('closure-compiler', function () {
 	        compilerPath: 'node_modules/google-closure-compiler/compiler.jar',
 	        compilerFlags: {
 		        compilation_level: 'SIMPLE_OPTIMIZATIONS',
-		        create_source_map: 'dist/Nutmeg-C.js.map'
+		        create_source_map: 'dist/Nutmeg-C.js.map',
 		        define: [],
 		        externs: [],
 		        only_closure_dependencies: true,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A tiny client-side website generator.",
   "main": "nutmeg.js",
   "scripts": {
+    "build": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Added build script so that gulp is not a global dependency.

Instead of running `gulp` and having to install gulp globally on your machine you can run `npm run build` here and it will use the gulp installed in your projects node_modules folder.
